### PR TITLE
[testing: new module] Module de threading automatique (autothread)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,106 @@
-# bot-base
+# Tellurion - Bot Discord
 
+[![viendez sur le serveur!](https://badgen.net/discord/members/7f8VZxE?icon=discord)](https://discord.gg/7f8VZxE) ![python version: 3.9+](https://badgen.net/badge/python/3.9+/blue)
+
+## Installer le bot
+
+Tout ce qui suit est prévu pour créer une instance "locale" du bot, afin de pouvoir développer sans casser le bot en ligne (pas comme moi, donc).
+
+### Prérequis
+
+On va partir du principe que vous savez déjà pourquoi vous voulez suivre ce tuto, et donc que vous avez sous la main :
+
+- Un compte GitHub, ainsi que Git installé sur votre machine.
+- Un compte Discord, ainsi qu'un serveur où vous êtes propriétaire.
+- Python 3.9 (ou ultérieur) installé et **disponible en ligne de commande** (pour ceux qui auraient l'idée saugrenue de développer sur Windows)
+
+### Etape 1 : Les modules à installer
+
+```
+pip install pipenv discord.py
+```
+
+(sous Windows, faites un clic droit, et sélectionnez `Ouvrir la fenêtre PowerShell ici` pour ouvrir un terminal.)
+
+### Etape 2 : Forker et cloner le repo
+
+Une fois que c'est fait, il faut maintenant forker le repo pour pouvoir continuer. Si vous êtes connecté en lisant ceci, remontez la page et appuyez sur le bouton Fork en haut à droite (sinon, connectez-vous et relisez cette phrase). Une fois que c'est fait, il ne reste plus qu'à cloner ce fork :
+
+- Si vous utilisez GitHub Desktop, cela se fait via le menu `File > Clone Repository...` : sélectionnez votre fork et choisissez ensuite l'emplacement du dossier sur votre disque.
+
+- Si vous êtes en ligne de commande :
+```bash
+$ git clone https://github.com/<votre-username-git>/tellurion-bot-py.git
+```
+(où `<votre-username-git>` est à remplacer avec ce qui correspond dans votre cas)
+
+### Etape 3 : Créer et inviter un bot discord
+
+Avant de donner vie à un clone d'Alset, il va falloir créer ce clone d'abord (logique).
+Rendez-vous sur https://discord.com/developers et connectez-vous. À partir de là, créez une nouvelle application et donnez-lui le nom que vous voulez.
+
+Après quoi, rendez-vous dans le menu `Bot`, et créez un bot pour votre application, qui servira de clone d'Alset.
+
+**Important** : Pour que le bot fonctionne correctement, activez les *Privileged Gateway Intents* qui se trouvent plus bas.
+
+Enfin, remontez la page et cliquez sur le bouton `Copy` : le *token* de votre bot (i.e. son jeton d'authentification) vient d'être copié dans votre presse-papier. Gardez-le dans un coin, parce qu'il va servir plus tard.
+
+Pour inviter le bot sur votre serveur, allez sur la page `OAuth2` et scrollez pour trouver un tableau de cases à cocher. Cochez `bot` et scrollez encore pour faire apparaître un autre tableau avec les permissions. Cochez celles qui sont pertinentes pour votre application.
+
+Une fois que c'est fait, une URL devrait avoir été générée entre les deux tableaux : copiez-la dans un autre onglet. Discord va vous demander où vous souhaitez inviter le bot - d'où l'intérêt de disposer d'un serveur où vous êtes propriétaire (ou que vous pouvez gérer *a minima*) - et si vous souhaitez lui refiler les droits que vous aurez choisis. Confirmez une dernière fois : votre bot est désormais présent sur votre serveur.
+
+### Etape 4 : Démarrer et interagir avec le bot
+
+C'est la partie un peu délicate de ce tutoriel. Mais si vous suivez les instructions, ça devrait aller.
+
+Dans un premier temps, avec votre éditeur préféré, créez un fichier appelé `.env` (à placer dans le même dossier que `main.py`) et mettez ceci :
+```
+# .env
+DISCORD_TOKEN='<votre-token>'
+```
+
+`<votre-token>` étant bien évidemment à remplacer avec le *token* du bot que vous aviez gardé dans un bloc-notes.
+
+Ensuite, dans un terminal, exécutez :
+```
+pipenv --python 3.10.6
+pipenv install
+```
+(si vous avez la version 3.10.6 d'installée, sinon ajustez en fonction)
+
+Cela devrait vous créer un environnement virtuel de travail et installer les dépendances nécessaires. A partir de là, démarrez une première fois le bot, puis arrêtez-le immédiatement après (avec un bon Ctrl-C). Cela permet de créer le dossier `data` avec les fichiers de configuration.
+
+On a presque fini. Il faut maintenant configurer manuellement le bot pour que vous puissiez faire des tests. Dans cette optique, ouvrez le fichier `data/config.toml`. Dans ce fichier, après l'en-tête, se trouvent des blocs comme ceci :
+```TOML
+[mod-modules]
+help_active = true
+color = 0
+auth_everyone = false
+authorized_roles = []
+authorized_users = []
+command_text = "modules"
+configured = false
+```
+Normalement, seuls deux blocs se trouvent ici : `mod-modules` et `mod-errors`. Il faut mettre `configured` à `true` pour que les modules soient exploitables.
+
+Par ailleurs, à la ligne 4 de ce fichier se trouve la variable `admin_users`. Si vous ne voulez pas que votre clone d'Alset vous interdise l'accès à ses commandes, vous devez rajouter votre Discord ID à cette liste :
+```TOML
+admin_users = [314159265358979323,]
+```
+Comment obtenir cet ID ? Rien de plus simple : activez le mode développeur dans les paramètres Discord (section `Avancés`), faites un clic droit sur votre pseudo, et sélectionnez `Copier l'identifiant`.
+
+(Note: il existe aussi la variable `admin_roles`, qui fonctionne avec des IDs de rôles.)
+
+L'heure est maintenant venue de lancer le bot. Ouvrez un terminal, placez-vous dans le dossier contenant `main.py`, et exécutez :
+```
+pipenv run py main.py
+```
+
+Si tout se déroule comme prévu, les premières lignes de la console devraient être celles-ci :
+
+Il ne vous reste plus qu'à vérifier que le bot répond correctement via Discord :
+```
+%modules list
+```
+
+Pour terminer, n'oubliez pas d'activer le module `restart` avec la commande `%modules enable restart` et en changeant la valeur de `configured` dans `data/config.toml` : cela vous permettra de stopper le bot pendant son exécution avec la commande `%restart`. Néanmoins, vous devrez le relancer manuellement via le terminal (ou bien coder un script pour le faire à votre place).

--- a/modules/autothread/__init__.py
+++ b/modules/autothread/__init__.py
@@ -9,36 +9,37 @@ class MainClass(BaseClassPython):
 		"commands": {
 			"{prefix}{command} enable": "Active la création automatique de threads dans le channel actuel",
 			"{prefix}{command} disable": "Désactive la création automatique de threads",
-			"{prefix}{command} list": "Affiche la liste des channels actifs (debug)"
+			"{prefix}{command} list": "Affiche la liste des salons enregistrés dans le module",
+			"{prefix}{command} clean": "Supprime tous les threads 'vides' (avec un seul message) du salon"
 	}}
 	active_channels = []
 
 	def __init__(self, client):
 		super().__init__(client)
-		self.config["auth_everyone"] = True
-		self.config["authorized_roles"] = []
+		self.config["auth_everyone"] = False
 		self.config["configured"] = True
 		self.config["help_active"] = True
 		self.config["command_text"] = "autothread"
-		self.config["color"] = 0x57ab1e
+		self.config["color"] = 0x840052 # Kernel's unique color
 		
 	async def on_ready(self):
-		#if self.objects.save_exists("active_channels"):
-		#	self.active_channels = self.objects.load_object("active_channels")
-		pass
+		if self.objects.save_exists("active_channels"):
+			self.active_channels = self.objects.load_object("active_channels")
 	
 	async def on_message(self, message):
 		await super().on_message(message)
+		
+		# Ignoring bot messages and commands
 		if message.author.bot or message.content.startswith(self.client.config["prefix"]):
-			# print("autothread: ignoring command/bot message")
 			return
+			
 		if str(message.channel.id) in self.active_channels:
-			await message.create_thread(name=f"Thread {message.author.name}-{randrange(18072)}")
+			await message.create_thread(name=f"Thread {message.author.name}-{randrange(1807)}")
 	
 	async def com_enable(self, message, args, kwargs):
 		if str(message.channel.id) not in self.active_channels:
 			self.active_channels.append(str(message.channel.id))
-			#self.save_channels()
+			self.saveChannels()
 			await message.channel.send("Salon ajouté.")
 		else:
 			await message.channel.send("AutoThread est déjà actif dans ce salon.")
@@ -46,7 +47,7 @@ class MainClass(BaseClassPython):
 	async def com_disable(self, message, args, kwargs):
 		if str(message.channel.id) in self.active_channels:
 			self.active_channels.remove(str(message.channel.id))
-			#self.save_channels()
+			self.saveChannels()
 			await message.channel.send("Salon retiré.")
 		else:
 			await message.channel.send("Le salon n'est pas enregistré dans AutoThread.")
@@ -58,8 +59,22 @@ class MainClass(BaseClassPython):
 			channel_list += "<#{0}>\n".format(chan_id)
 			
 		await message.channel.send(f"`autothread` | **Salons enregistrés ({len(self.active_channels)})** \n" + channel_list)
+	
+	async def com_clean(self, message, args, kwargs):
+		if str(message.channel.id) in self.active_channels:
+			deleted_threads = 0
+			for thread in message.channel.threads:
+				# Deleting threads only if they have one message
+				messages = [msg async for msg in thread.history(limit=5)]
+				if not len(messages) >= 2:
+					deleted_threads += 1
+					await thread.delete()
+					
+			await message.channel.send(f"`autothread clean` | Threads supprimés : {deleted_threads}")
+		else:
+			await message.channel.send("Le salon n'est pas enregistré dans AutoThread.")
 		
 
-	#def save_channels(self):
-	#	self.mainclass.objects.save_object("active_channels", self.active_channels)
+	def saveChannels(self):
+		self.objects.save_object("active_channels", self.active_channels)
 	

--- a/modules/autothread/__init__.py
+++ b/modules/autothread/__init__.py
@@ -1,5 +1,6 @@
 import discord
 from modules.base import BaseClassPython
+from random import randrange
 
 class MainClass(BaseClassPython):
 	name = "AutoThread"
@@ -27,14 +28,18 @@ class MainClass(BaseClassPython):
 		pass
 	
 	async def on_message(self, message):
+		await super().on_message(message)
+		if message.author.bot or message.content.startswith(self.client.config["prefix"]):
+			# print("autothread: ignoring command/bot message")
+			return
 		if str(message.channel.id) in self.active_channels:
-			message.create_thread(name="Thread")
+			await message.create_thread(name=f"Thread {message.author.name}-{randrange(18072)}")
 	
 	async def com_enable(self, message, args, kwargs):
 		if str(message.channel.id) not in self.active_channels:
 			self.active_channels.append(str(message.channel.id))
 			#self.save_channels()
-			await message.channel.send("Channel ajouté.")
+			await message.channel.send("Salon ajouté.")
 		else:
 			await message.channel.send("AutoThread est déjà actif dans ce salon.")
 			
@@ -42,14 +47,18 @@ class MainClass(BaseClassPython):
 		if str(message.channel.id) in self.active_channels:
 			self.active_channels.remove(str(message.channel.id))
 			#self.save_channels()
-			await message.channel.send("Channel retiré.")
+			await message.channel.send("Salon retiré.")
 		else:
 			await message.channel.send("Le salon n'est pas enregistré dans AutoThread.")
 	
 	async def com_list(self, message, args, kwargs):
-		print("Command list triggered.")
-		await message.channel.send("Hello.")
-		await message.channel.send(f"Active channels: {self.active_channels}")
+		
+		channel_list = ""
+		for chan_id in self.active_channels:
+			channel_list += "<#{0}>\n".format(chan_id)
+			
+		await message.channel.send(f"`autothread` | **Salons enregistrés ({len(self.active_channels)})** \n" + channel_list)
+		
 
 	#def save_channels(self):
 	#	self.mainclass.objects.save_object("active_channels", self.active_channels)

--- a/modules/autothread/__init__.py
+++ b/modules/autothread/__init__.py
@@ -1,0 +1,56 @@
+import discord
+from modules.base import BaseClassPython
+
+class MainClass(BaseClassPython):
+	name = "AutoThread"
+	help = {
+		"description": "Crée automatiquement un thread par message, en fonction du channel",
+		"commands": {
+			"{prefix}{command} enable": "Active la création automatique de threads dans le channel actuel",
+			"{prefix}{command} disable": "Désactive la création automatique de threads",
+			"{prefix}{command} list": "Affiche la liste des channels actifs (debug)"
+	}}
+	active_channels = []
+
+	def __init__(self, client):
+		super().__init__(client)
+		self.config["auth_everyone"] = True
+		self.config["authorized_roles"] = []
+		self.config["configured"] = True
+		self.config["help_active"] = True
+		self.config["command_text"] = "autothread"
+		self.config["color"] = 0x57ab1e
+		
+	async def on_ready(self):
+		#if self.objects.save_exists("active_channels"):
+		#	self.active_channels = self.objects.load_object("active_channels")
+		pass
+	
+	async def on_message(self, message):
+		if str(message.channel.id) in self.active_channels:
+			message.create_thread(name="Thread")
+	
+	async def com_enable(self, message, args, kwargs):
+		if str(message.channel.id) not in self.active_channels:
+			self.active_channels.append(str(message.channel.id))
+			#self.save_channels()
+			await message.channel.send("Channel ajouté.")
+		else:
+			await message.channel.send("AutoThread est déjà actif dans ce salon.")
+			
+	async def com_disable(self, message, args, kwargs):
+		if str(message.channel.id) in self.active_channels:
+			self.active_channels.remove(str(message.channel.id))
+			#self.save_channels()
+			await message.channel.send("Channel retiré.")
+		else:
+			await message.channel.send("Le salon n'est pas enregistré dans AutoThread.")
+	
+	async def com_list(self, message, args, kwargs):
+		print("Command list triggered.")
+		await message.channel.send("Hello.")
+		await message.channel.send(f"Active channels: {self.active_channels}")
+
+	#def save_channels(self):
+	#	self.mainclass.objects.save_object("active_channels", self.active_channels)
+	

--- a/modules/autothread/version.json
+++ b/modules/autothread/version.json
@@ -1,0 +1,11 @@
+{
+  "version":"0.1.0",
+  "type": "python",
+  "dependencies": {
+
+  },
+  "bot_version": {
+    "min": "0.1.0",
+    "max": "0.1.0"
+  }
+}


### PR DESCRIPTION
Bon, ça fait des lustres qu'on se dit qu'un module pour threader automatiquement serait quand même pratique (surtout dans #memes), donc le voilà. Il y a quatre commandes :

- `list` : affiche les salons où le module est actif
- `enable/disable` : active/désactive le threading automatique dans un channel.
- `clean` : comme ce module va générer beaucoup de threads qui ne seront pas nécessairement utilisés, cette commande fait le ménage. (évolution possible: nettoyage automatique à intervalles réguliers)

Enfin, il semblerait que le README originel a été supplanté lors du merge, donc voilà une version plus verbeuse qu'un "bot-base" :upside_down_face: 